### PR TITLE
Added summary field in guides for use with social meta tags

### DIFF
--- a/get-started-building-a-blitz-website-with-directus/index.md
+++ b/get-started-building-a-blitz-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building a Blitz Website with Directus
+summary: This example will show you how to link a simple Blitz blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./blitz-example.webp

--- a/get-started-building-a-gatsby-website-with-directus/index.md
+++ b/get-started-building-a-gatsby-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building a Gatsby Website with Directus
+summary: This example will show you how to link a simple Gatsby frontend blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./gatsby-example-1.webp

--- a/get-started-building-a-next-website-with-directus/index.md
+++ b/get-started-building-a-next-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building a Next.js Website with Directus
+summary: This example will show you how to link a simple Next.js blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./next-example.webp

--- a/get-started-building-a-nuxt-2-website-with-directus/index.md
+++ b/get-started-building-a-nuxt-2-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building a Nuxt 2 Website with Directus
+summary: This example will show you how to link a simple Nuxt.js blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./nuxt-example.webp

--- a/get-started-building-a-nuxt-3-blog-with-directus/index.md
+++ b/get-started-building-a-nuxt-3-blog-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Build a blog with Nuxt 3 & Directus
+summary: This guide shows you how to build a blog with Nuxt 3 and Directus step by step.
 date: 2022-04-07
 author: Conner Bachmann
 image: ./build-a-blog-with-nuxt3-and-directus.webp

--- a/get-started-building-a-react-website-with-directus/index.md
+++ b/get-started-building-a-react-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building a React Website with Directus
+summary: This example will show you how to link a simple React frontend blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./react-example.webp

--- a/get-started-building-a-svelte-website-with-directus/index.md
+++ b/get-started-building-a-svelte-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building a Svelte Website with Directus
+summary: This example will show you how to link a simple Svelte frontend blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./svelte-example.webp

--- a/get-started-building-a-sveltekit-website-with-directus/index.md
+++ b/get-started-building-a-sveltekit-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building a Sveltekit Website with Directus
+summary: This example will show you how to link a simple SvelteKit frontend blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./sveltekit-example.webp

--- a/get-started-building-a-vue-website-with-directus/index.md
+++ b/get-started-building-a-vue-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building a Vue Website with Directus
+summary: This example will show you how to link a simple Vue frontend blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./vue-example.webp

--- a/get-started-building-an-angular-website-with-directus/index.md
+++ b/get-started-building-an-angular-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building an Angular Website with Directus
+summary: This example will show you how to link a simple Angular frontend blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./angular-example.webp

--- a/get-started-building-an-astro-website-with-directus/index.md
+++ b/get-started-building-an-astro-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building an Astro Website with Directus
+summary: This example will show you how to link a simple Astro frontend blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./astro-example.webp

--- a/get-started-building-an-eleventy-website-with-directus/index.md
+++ b/get-started-building-an-eleventy-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building an Eleventy Website with Directus
+summary: This example will show you how to link a simple Eleventy frontend blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-02-21
 author: Eron Powell & Azri Kahar
 image: ./11ty-example.webp

--- a/get-started-building-an-iles-website-with-directus/index.md
+++ b/get-started-building-an-iles-website-with-directus/index.md
@@ -1,5 +1,6 @@
 ---
 title: Get Started Building an Îles Website with Directus
+summary: This example will show you how to link a simple Îles frontend blog template to a Directus Project with a simple SQLite database containing a few blog posts.
 date: 2022-04-19
 author: Eron Powell & Máximo Mussini
 image: ./iles-example.webp


### PR DESCRIPTION
Added a `summary` field to all guides pre-filled with the first quote of the guide as that looked most descriptive to me.
Possibly some descriptions purposefully written for social sharing might be better.