### PR TITLE
Update nuxt3 guide

### DIFF
--- a/get-started-building-a-nuxt-3-blog-with-directus/index.md
+++ b/get-started-building-a-nuxt-3-blog-with-directus/index.md
@@ -54,7 +54,7 @@ Your Nuxt 3 application is now running at <http://localhost:3000>.
 Change the URL to your Directus server in the configuration and add the modules we just installed. ✨
 
 ```ts
-import { defineNuxtConfig } from "nuxt3";
+import { defineNuxtConfig } from 'nuxt/config';
 
 export default defineNuxtConfig({
 	modules: ["nuxt-directus", "@nuxtjs/tailwindcss"],


### PR DESCRIPTION
With nuxt3 officially out, there’s some updates needed to make the guide work with it.

The primary and really only one:

```js
import { defineNuxtConfig } from 'nuxt3';
```

Becomes

```js
import { defineNuxtConfig } from 'nuxt/config';
```
